### PR TITLE
Restructure interface for command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,6 @@ Below is a summarized list of the available helpers.  You can refer to the [defi
 | --- | --- |
 | `result=$("cmd.sh")` | Execute a command and return the stdout |
 | `$.echo("cmd.sh")` | Execute a command and stream stdout to console without returning a value; also aliased as `exec()`. |
-| `$.noThrow("cmd.sh")` | Execute a command and do not throw an error if its exit code is not 0 |
-| `$.quiet("cmd.sh")` | Execute a command and do not echo the command before running it |
-| `$.retry("cmd.sh", 5)` | Execute a command and if it throws and error, retry up to a number of times until it succeeds |
 
 **File System**
 |     | Description |
@@ -96,7 +93,6 @@ Below is a summarized list of the available helpers.  You can refer to the [defi
 | `await http.delete("https://www.myapi.com", { data: "1" })` | Make a HTTP DELETE request and return the response body data                                             |
 | `await http("GET", "https://www.myapi.com")`                | Make a HTTP request and return the response: (`{ data, headers, statusCode, statusMessage }`)            |
 | `await http.noThrow("GET", "https://www.myapi.com")`        | Make a HTTP request and do not throw an error if status code is not 20X                                  |
-| `await http.retry("GET", "https://www.myapi.com")`          | Make a HTTP request and if response status code is not 20X, retry up to a number of times until it is    |
 
 ## Examples
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -40,22 +40,5 @@ it("should return CommandError with expected values", () => {
 });
 
 it("$.noThrow should not throw with non zero exit code", () => {
-  expect($.noThrow("unknown_command")).toContain("not found");
-});
-
-it("$.retry should retry when first call results in error", () => {
-  const spawnSyncSpy = jest.spyOn(child_process, "spawnSync");
-  const consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
-
-  try {
-    spawnSyncSpy.mockImplementationOnce(() => {
-      throw new Error("error!");
-    });
-    expect($.retry("echo 'test'", 5, 500)).toEqual("test");
-    expect(spawnSyncSpy).toBeCalledTimes(2);
-    expect(consoleLogSpy).toBeCalledTimes(4);
-  } finally {
-    spawnSyncSpy.mockRestore();
-    consoleLogSpy.mockRestore();
-  }
+  expect($("unknown_command", { noThrow: true })).toContain("not found");
 });


### PR DESCRIPTION
Restructure interface for command execution.  Allow passing in options
parameter that controls behavior of command execution.  This avoids awkward
global settings like $.timeout and inconsistent interfaces for supporting
methods like $.quiet.

$.noThrow, $.quiet, and $.retry are all being removed.  Their function can be
achieved with the options parameter.

Also, remove http.retry method.