### PR TITLE
Allow options to be passed to `http()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,23 +220,29 @@ try {
 }
 ```
 
-#### $.noThrow()
+#### `noThrow` option
 
-You can call `$.noThrow()` to prevent an error from being thrown. Instead, the stderr will be returned.
+You can pass in the option `noThrow: true` to prevent an error from being thrown. Instead, the stderr will be returned.
 
 Example:
 
 ```
 // This command will error out but will not throw because `$.noThrow()` was called.
-let content=$(`cat invalid.txt`)
+let content=$(`cat invalid.txt`, { noThrow: true})
 echo(content);
 
 > cat: invalid.txt: No such file or directory
 ```
 
-### Options
+### Command Options
 
-- `$.shell` - By default, commands will be run inside of a shell (`/bin/sh` on *nix systems and `process.env.ComSpec` on Windows).  You can specify the path to a different shell to execute commands with by setting the `$.shell` config variable.  All subsequent command executions will honor this setting.  For example: `$.shell = "/bin/bash";`
+`$()` and `$.echo()` accept an `options` parameter object that may contain any of the following fields:
+ 
+- `echoCommand: boolean` - If true will echo the command itself before running it (Default: `true`)
+- `noThrow: boolean` -  If set to true, will not throw if the command returns a non-zero exit code (Default: `false`)
+- `timeout: number` - In milliseconds the maximum amount of time the process is allowed to run (Default: `undefined` (unlimited))
+- `shell: string` - By default, commands will be run inside of a shell (`/bin/sh` on *nix systems and `process.env.ComSpec` on Windows).  This option can be used to specify the path to a different shell to execute commands with.  For example, you could specify `shell: "/bin/bash"` to use bash.
+  `maxBuffer: number` - Specifies the largest number of bytes allowed on stdout or stderr. If this value is exceeded, the child process will be terminated. (Default: `268435456` (256MB))
 
 ## HTTP Request Helpers
 

--- a/README.md
+++ b/README.md
@@ -85,14 +85,13 @@ Below is a summarized list of the available helpers.  You can refer to the [defi
 **Note:** The HTTP helpers are asynchronous and return a Promise.
 
 |     | Description |
-| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | `await http.get("https://www.myapi.com")`                   | Make a HTTP GET request and return the response body data                                                |
-| `await http.post("https://www.myapi.com", { data: "1" }) `  | Make a HTTP POST request and return the response body data                                               |
+| `await http.post("https://www.myapi.com", { data: "1" })`   | Make a HTTP POST request and return the response body data                                               |
 | `await http.put("https://www.myapi.com", { data: "1" })`    | Make a HTTP PUT request and return the response body data                                                |
 | `await http.patch("https://www.myapi.com", { data: "1" })`  | Make a HTTP PATCH request and return the response body data                                              |
 | `await http.delete("https://www.myapi.com", { data: "1" })` | Make a HTTP DELETE request and return the response body data                                             |
-| `await http("GET", "https://www.myapi.com")`                | Make a HTTP request and return the response: (`{ data, headers, statusCode, statusMessage }`)            |
-| `await http.noThrow("GET", "https://www.myapi.com")`        | Make a HTTP request and do not throw an error if status code is not 20X                                  |
+| `await http("POST", "https://www.myapi.com", { data: "1" }, { headers: { Accept: "application/json" } })`                | Make a HTTP request and return the response: (`{ data, headers, statusCode, statusMessage }`)            |
 
 ## Examples
 
@@ -317,20 +316,28 @@ try {
 }
 ```
 
-#### http.noThrow()
+#### `noThrow` option
 
-You can call `http.noThrow()` to prevent an error from being thrown. Instead, the response will be returned.
+You can pass in the option `noThrow: true` when calling `http()` to prevent an error from being thrown when the response status is not 2xx. Instead, the response will be returned.
 
 Example:
 
 ```
-const response = await http.noThrow("GET", "https://www.myapi.com);
+const response = await http("POST", "https://www.myapi.com", { data: 2 }, { noThrow: true });
 
 echo(response.data) // "A server error occurred.  Please try again later."
 echo(response.headers) // { "Content-Type": "text/plain" }
 echo(response.statusCode) // 500
 echo(response.statusMessage) // "Internal Server Error"
 ```
+
+### HTTP Request Options
+
+`http()` accepts an `options` parameter object that may contain any of the following fields:
+ 
+- `headers: object` - The request headers to send with the request.  A set of default headers will be included with the request even if not specified here.  See "Default Headers" section above for more info.
+- `timeout: number` - The number of milliseconds of inactivity before a socket is presumed to have timed out (Default: `120000` (2 minutes))
+- `noThrow: boolean` - If set to true, will not throw if the response status code is not 2xx (Default: false)
 
 ## Installation
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -332,6 +332,7 @@ const _$ = (command: string, options: ICommandOptions = {}): string => {
     {
       echoStdout: false,
       echoCommand: true,
+      noThrow: false,
       shell: true,
       maxBuffer: 1024 * 1024 * 256 /* 256MB */,
     } as ICommandOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -386,29 +386,38 @@ global.exec = _$.echo;
 // HTTP
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 export type HttpData = object | stream.Readable | null;
-export interface IHttpRequestOptions {
+export interface IHttpRawRequestOptions {
   protocol: string;
   hostname: string;
   port: number;
   path: string;
   url: string;
   method: string;
-  headers: NodeJS.Dict<string | string[]>;
-  timeout: number;
+  headers?: NodeJS.Dict<string | string[]>;
+  /**
+   * The number of milliseconds of inactivity before a socket is presumed to have timed out.
+   */
+  timeout?: number;
 }
+export type IHttpRequestOptions = Pick<Partial<IHttpRawRequestOptions>, "headers" | "timeout"> & {
+  /**
+   * If set to true, will not throw if the response status code is not 2xx
+   */
+  noThrow?: boolean;
+};
 export interface IHttpResponse<T> {
   data: T;
   body: string;
   headers: NodeJS.Dict<string | string[]>;
   statusCode: number | undefined;
   statusMessage: string | undefined;
-  requestOptions: IHttpRequestOptions;
+  requestOptions: IHttpRawRequestOptions;
 }
 export class HttpRequestError<T> extends Error {
-  public request: IHttpRequestOptions;
+  public request: IHttpRawRequestOptions;
   public response: IHttpResponse<T> | null;
 
-  constructor(message: string, request: IHttpRequestOptions, response: IHttpResponse<T> | null = null) {
+  constructor(message: string, request: IHttpRawRequestOptions, response: IHttpResponse<T> | null = null) {
     const errorMessage = !!response
       ? `${response.statusCode} ${response.statusMessage}\n${request.method} ${request.url}`
       : `${message}\n${request.method} ${request.url}`;
@@ -446,20 +455,24 @@ const _http = <T>(
   method: HttpMethod,
   url: string,
   data: HttpData = null,
-  headers: { [name: string]: string } = {}
+  options: IHttpRequestOptions = {}
 ): Promise<IHttpResponse<T>> => {
   const parsedUrl = new URL(url);
   const isHTTPS = parsedUrl.protocol.startsWith("https");
-  const requestOptions: IHttpRequestOptions = {
-    protocol: parsedUrl.protocol,
-    hostname: parsedUrl.hostname,
-    port: !!parsedUrl.port ? Number(parsedUrl.port) : isHTTPS ? 443 : 80,
-    path: parsedUrl.pathname + parsedUrl.search,
-    url,
-    method,
-    headers,
-    timeout: _http.timeout,
-  };
+
+  const rawRequestOptions: IHttpRawRequestOptions = Object.assign(
+    {
+      protocol: parsedUrl.protocol,
+      hostname: parsedUrl.hostname,
+      port: !!parsedUrl.port ? Number(parsedUrl.port) : isHTTPS ? 443 : 80,
+      path: parsedUrl.pathname + parsedUrl.search,
+      url,
+      method,
+      headers: {},
+      timeout: 120000 /* 2 minutes */,
+    },
+    options
+  );
 
   const tryParseJson = (data: string) => {
     // Tries to parse JSON and returns parsed object if successful.  If not, returns false.
@@ -474,18 +487,22 @@ const _http = <T>(
     }
   };
 
-  let requestBodyData = data ?? "";
+  if (!!options.headers) {
+    options.headers["Accept"] = options.headers["Accept"] || "*/*";
+    options.headers["Accept-Encoding"] = options.headers["Accept-Encoding"] || "gzip";
+    options.headers["Connection"] = options.headers["Connection"] || "close";
+    options.headers["User-Agent"] = options.headers["User-Agent"] || "jsh";
+    options.headers["Host"] = options.headers["Host"] || `${rawRequestOptions.hostname}:${rawRequestOptions.port}`;
+  }
 
-  headers["Accept"] = headers["Accept"] || "*/*";
-  headers["Accept-Encoding"] = headers["Accept-Encoding"] || "gzip";
-  headers["Connection"] = headers["Connection"] || "close";
-  headers["User-Agent"] = headers["User-Agent"] || "jsh";
-  headers["Host"] = headers["Host"] || `${requestOptions.hostname}:${requestOptions.port}`;
+  let requestBodyData = data ?? "";
 
   if (!(data instanceof stream.Readable) && typeof data == "object") {
     // Add JSON headers if needed
-    headers["Content-Type"] = headers["Content-Type"] || "application/json; charset=utf-8";
-    headers["Accept"] = headers["Accept"] || "application/json";
+    if (!!options.headers) {
+      options.headers["Content-Type"] = options.headers["Content-Type"] || "application/json; charset=utf-8";
+      options.headers["Accept"] = options.headers["Accept"] || "application/json";
+    }
 
     requestBodyData = JSON.stringify(data);
   }
@@ -497,10 +514,10 @@ const _http = <T>(
 
   return new Promise<IHttpResponse<T>>((resolve, reject) => {
     const onRequestError = (errorMessage: string) => {
-      reject(new HttpRequestError<T>(errorMessage, requestOptions));
+      reject(new HttpRequestError<T>(errorMessage, rawRequestOptions));
     };
 
-    const req = request(requestOptions, (res) => {
+    const req = request(rawRequestOptions, (res) => {
       let responseBody: any = "";
 
       const onResponseEnd = () => {
@@ -513,12 +530,16 @@ const _http = <T>(
           headers: res.headers,
           statusCode: res.statusCode,
           statusMessage: res.statusMessage,
-          requestOptions: requestOptions,
+          requestOptions: rawRequestOptions,
         };
 
         if (!response.statusCode?.toString().startsWith("2")) {
-          const errorMessage = response.statusMessage ?? "Request Error";
-          reject(new HttpRequestError<T>(errorMessage, requestOptions, response));
+          if (options.noThrow === true) {
+            resolve(response);
+          } else {
+            const errorMessage = response.statusMessage ?? "Request Error";
+            reject(new HttpRequestError<T>(errorMessage, rawRequestOptions, response));
+          }
         } else {
           resolve(response);
         }
@@ -568,34 +589,7 @@ const _http = <T>(
     }
   });
 };
-_http.timeout = 120000; // 2 minutes
 global.http = _http;
-
-/**
- * Makes a synchronous HTTP request and returns the response.   Will not throw an error if the response status code is not 2xx.
- * @param method
- * @param url
- * @param data
- * @param headers
- * @returns
- */
-_http.noThrow = async <T>(
-  method: HttpMethod,
-  url: string,
-  data: HttpData = null,
-  headers: { [name: string]: string } = {}
-): Promise<IHttpResponse<T>> => {
-  try {
-    return await _http<T>(method, url, data, headers);
-  } catch (err) {
-    if (err instanceof HttpRequestError) {
-      return err.response as IHttpResponse<T>;
-    } else {
-      // Unknown error so rethrow
-      throw err;
-    }
-  }
-};
 
 /**
  * Makes a GET HTTP request and returns the response data.  Will throw an error if the response status code is not 2xx.
@@ -604,7 +598,7 @@ _http.noThrow = async <T>(
  * @returns
  */
 _http.get = async <T>(url: string, headers: { [name: string]: string } = {}) => {
-  const response = await _http<T>("GET", url, null, headers);
+  const response = await _http<T>("GET", url, null, { headers });
   return response.data;
 };
 /**
@@ -614,7 +608,7 @@ _http.get = async <T>(url: string, headers: { [name: string]: string } = {}) => 
  * @returns
  */
 _http.post = async <T>(url: string, data: HttpData, headers: { [name: string]: string } = {}) => {
-  const response = await _http<T>("POST", url, data, headers);
+  const response = await _http<T>("POST", url, data, { headers });
   return response.data;
 };
 /**
@@ -624,7 +618,7 @@ _http.post = async <T>(url: string, data: HttpData, headers: { [name: string]: s
  * @returns
  */
 _http.put = async <T>(url: string, data: HttpData, headers: { [name: string]: string } = {}) => {
-  const response = await _http<T>("PUT", url, data, headers);
+  const response = await _http<T>("PUT", url, data, { headers });
   return response.data;
 };
 /**
@@ -634,7 +628,7 @@ _http.put = async <T>(url: string, data: HttpData, headers: { [name: string]: st
  * @returns
  */
 _http.patch = async <T>(url: string, data: HttpData, headers: { [name: string]: string } = {}) => {
-  const response = await _http<T>("PATCH", url, data, headers);
+  const response = await _http<T>("PATCH", url, data, { headers });
   return response.data;
 };
 /**
@@ -644,7 +638,7 @@ _http.patch = async <T>(url: string, data: HttpData, headers: { [name: string]: 
  * @returns
  */
 _http.delete = async <T>(url: string, data: HttpData, headers: { [name: string]: string } = {}) => {
-  const response = await _http<T>("DELETE", url, data, headers);
+  const response = await _http<T>("DELETE", url, data, { headers });
   return response.data;
 };
 global.http = _http;

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -42,10 +42,10 @@ it("should throw error on status not in 200 range", async () => {
   }
 });
 
-it("should not throw error when .noThrow is called", async () => {
+it("should not throw error when noThrow option is used", async () => {
   expect.assertions(2);
   fakeweb.registerUri({ uri: "http://errorserver.ts/", body: `{ "text": "Error" }`, statusCode: 500 });
-  const response = await http.noThrow("GET", "http://errorserver.ts/");
+  const response = await http("GET", "http://errorserver.ts/", null, { noThrow: true });
   expect(response.statusCode).toBe(500);
   expect(response.data).toEqual({ text: "Error" });
 });
@@ -56,31 +56,35 @@ it("should PUT data", async () => {
   expect(response).toEqual({ text: "It worked", status: true });
 });
 
-it("should include correct default headers", async () => {  
+it("should include correct default headers", async () => {
   fakeweb.registerUri({
-    uri: "https://putfake.ts/?parma1=value",  
+    uri: "https://putfake.ts/?parma1=value",
   });
 
   jest.spyOn(https, "request");
   await http.put("https://putfake.ts/?parma1=value", { param: "one" });
 
-  expect(https.request).toHaveBeenNthCalledWith(1, {
-    headers: {
-      Accept: "*/*",
-      "Accept-Encoding": "gzip",
-      Connection: "close",
-      "Content-Type": "application/json; charset=utf-8",
-      Host: "putfake.ts:443",
-      "User-Agent": "jsh",
+  expect(https.request).toHaveBeenNthCalledWith(
+    1,
+    {
+      headers: {
+        Accept: "*/*",
+        "Accept-Encoding": "gzip",
+        Connection: "close",
+        "Content-Type": "application/json; charset=utf-8",
+        Host: "putfake.ts:443",
+        "User-Agent": "jsh",
+      },
+      hostname: "putfake.ts",
+      method: "PUT",
+      path: "/?parma1=value",
+      port: 443,
+      url: "https://putfake.ts/?parma1=value",
+      protocol: "https:",
+      timeout: 120000,
     },
-    hostname: "putfake.ts",
-    method: "PUT",
-    path: "/?parma1=value",
-    port: 443,
-    url: "https://putfake.ts/?parma1=value",
-    protocol: "https:",
-    timeout: 120000,
-  }, expect.any(Function));  
+    expect.any(Function)
+  );
 });
 
 it("accepts a file stream", async () => {


### PR DESCRIPTION
- headers parameter is remove and options parameter is added.  Headers can be specified as part of the options object.
- remove http.noThrow