### PR TITLE
Misc fixes

### DIFF
--- a/bin/jsh.mjs
+++ b/bin/jsh.mjs
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
 import * as jsh from "jsh";
 import * as path from "path";
-usage(`\
-Usage: jsh <script> [args]\
-`);
 
 args.assertCount(1);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ const _printUsageAndExit = (exitCode = 1, additionalMessage?: string): void => {
 };
 
 const _usage = (message: string, printAndExitIfHelpArgumentSpecified = true) => {
-  defaultUsageMessage = message;
+  defaultUsageMessage = message?.replace(/\n+$/, ""); // Trailing newlines will be handled internally so remove them if present
 
   if (printAndExitIfHelpArgumentSpecified && (process.argv.includes("--help") || process.argv.includes("-h"))) {
     _printUsageAndExit(0);

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -24,8 +24,7 @@ it("assert 2 arguments when 1 is provided", () => {
     "test/fixtures/assert-arg-count-2.ts",
     "--one",
   ]);
-  expect(result.stderr.toString()).toContain("Usage: assert-arg-count-2.ts\n\n");
-  expect(result.stderr.toString()).toContain("\n\n" + red("2 arguments were expected but 1 was provided"));
+  expect(result.stderr.toString()).toContain("Usage: assert-arg-count-2.ts\n\n" + red("2 arguments were expected but 1 was provided"));  
 });
 
 it("assert 2 arguments", () => {


### PR DESCRIPTION
- Prevent extra newlines when printing usage message
- Fix jsh shebang with `--help` or `-h` not showing correct usage message